### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["tracing", "oslog", "os_log", "macos", "ios"]
 repository = "https://github.com/Absolucy/tracing-oslog"
 
 [dependencies]
-cfg-if = "1.0.0"
-fnv = "1.0.7"
-once_cell = "1.8.0"
-parking_lot = "0.11.2"
-tracing-core = "0.1.21"
-tracing-subscriber = "0.3.1"
+cfg-if = "1.0"
+fnv = "1.0"
+once_cell = "1.8"
+parking_lot = "0.12"
+tracing-core = "0.1"
+tracing-subscriber = "0.3"
 
 [build-dependencies]
-bindgen = "0.59.1"
-cc = "1.0.71"
+bindgen = "0.63"
+cc = "1.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"


### PR DESCRIPTION
This pull requests updates versions of bindgen and parking_lot to newer version. Bingen update is crucial as in [PR#2284](https://github.com/rust-lang/rust-bindgen/pull/2284) they have updated crate structure to remove a lot of unused dependencies.

I also remove the the patch version from the crates.
The reason it is better not to keep patch versions is that tracing-oslog is a library create. It would be always a dependency of some other (let's call it main) crate. If this main crate depends on, say, on ``tracing-core = "0.1.20"``, then having  ``tracing-core = "0.1.21"`` in this crate might create a problem. Assuming all dependencies follow semver, ``tracing-oslog`` should work fine with any patch version

See more [here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) and [here](https://doc.rust-lang.org/cargo/reference/semver.html)

P.S. Any plans to make tracing-oslog v0.2.0 soon?