### PR TITLE
Support macabi targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing-core = "0.1"
 tracing-subscriber = "0.3"
 
 [build-dependencies]
-bindgen = "0.63"
+bindgen = "0.64"
 cc = "1.0"
 
 [package.metadata.docs.rs]

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,12 @@ fn main() {
 
 	let mut args = Vec::<String>::new();
 	if env::var("CARGO_CFG_TARGET_OS").expect("failed to get target os") == "ios" {
-		args.push("-miphoneos-version-min=10.0".to_string());
+		let version = if "macabi" == env::var("CARGO_CFG_TARGET_ABI").unwrap_or_default() {
+			"14.0"
+		} else {
+			"10.0"
+		};
+		args.push(format!("-miphoneos-version-min={version}"));
 	}
 
 	let bindings = bindgen::Builder::default()


### PR DESCRIPTION
Closes issue #4 

The catalysts targets are available starting from v. 14.

I've also updated bindgen to the latest version (not required as a fix, but good to have deps up to date).

Way to test:
```
cargo +nightly build --target x86_64-apple-ios-macabi -Zbuild-std -vv
cargo +nightly build --target aarch64-apple-ios-macabi -Zbuild-std -vv
```
