### PR TITLE
Make `OsLogger` implement `Default` via `OS_LOG_DEFAULT`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tracing-core = "0.1"
 tracing-subscriber = "0.3"
 
 [build-dependencies]
-bindgen = "0.64"
+bindgen = "0.69"
 cc = "1.0"
 
 [package.metadata.docs.rs]

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
 
 	let bindings = bindgen::Builder::default()
 		.header("wrapper.h")
-		.parse_callbacks(Box::new(bindgen::CargoCallbacks))
+		.parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
 		.allowlist_function("_?os_activity_.*")
 		.allowlist_function("os_log_.*")
 		.allowlist_function("os_release")

--- a/wrapper.c
+++ b/wrapper.c
@@ -3,3 +3,6 @@
 void wrapped_os_log_with_type(os_log_t log, os_log_type_t type, const char* message) {
     os_log_with_type(log, type, "%{public}s", message);
 }
+os_log_t wrapped_os_log_default(void) {
+    return OS_LOG_DEFAULT;
+}

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,3 +1,5 @@
 #include <os/log.h>
 #include <os/activity.h>
-void wrapped_os_log_with_type(os_log_t log, os_log_type_t type, const char* message);
+
+void wrapped_os_log_with_type(os_log_t log, os_log_type_t type, const char *message);
+os_log_t wrapped_os_log_default(void);


### PR DESCRIPTION
Hi @Absolucy, thanks for making this crate!

I've added `Default` to `OsLogger` so you can instantiate it if you don't want to specify a subsystem and category.

I've also updated `bindgen` to the latest version. Please note that `tracing-oslog 0.1.2` (the latest release) depends on `atty` (via an old `bindgen` version) which has a [**potential security issue**](https://rustsec.org/advisories/RUSTSEC-2021-0145).