### PR TITLE
Reduce amount of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ documentation = "https://docs.rs/tracing-oslog"
 rust-version = "1.77"
 
 [dependencies]
-tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "registry"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "std",
+    "registry",
+] }
 cfg-if = "1.0"
-once_cell = "1.8"
-parking_lot = "0.12"
 tracing-core = "0.1"
 
 [build-dependencies]


### PR DESCRIPTION
Remove:
- `cfg-if`, since it only helps very little in our case.
- `once_cell`, it can easily be replaced by OnceLock.
- `parking_lot`, the standard library's locks are just as good nowadays.
