### PR TITLE
Bump version to v0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-oslog"
 description = "A layer for tracing that outputs to the oslog on macOS/iOS"
 authors = ["Lucy <lucy@absolucy.moe>"]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Zlib"
 categories = [


### PR DESCRIPTION
To get https://github.com/Absolucy/tracing-oslog/pull/12 released. Would be nice if we could get in https://github.com/Absolucy/tracing-oslog/pull/13 and https://github.com/Absolucy/tracing-oslog/pull/19 first though.